### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#NPReachability
+# NPReachability
 - Originally By [Nick Paulson](http://twitter.com/nckplsn)
 - KVO support added by [Adam Ernst](http://www.adamernst.com/)
 - ARC support and changes to the interface by


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
